### PR TITLE
'min-width: fit-content' is not supported by Samsung Internet. Add 'min-width: -webkit-fill-available' to support Samsung Internet 5.0+.

### DIFF
--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -11,6 +11,7 @@
 button {
     flex-grow: 1;
     flex-basis: 100px;
+    min-width: -webkit-fill-available;
     min-width: fit-content;
 }
 
@@ -26,6 +27,7 @@ button {
 
 .driverSel {
     flex: 1 1 40%;
+    min-width: -webkit-fill-available;
     min-width: fit-content;
 }
 


### PR DESCRIPTION
Fixes #70