### PR TITLE
Fix regex for time format parsing in serial data

### DIFF
--- a/src/serialport.ts
+++ b/src/serialport.ts
@@ -37,7 +37,7 @@ async function handleSerialPort() {
 async function parseSerialData(data: string): Promise<void> {
     accumulatedData += data;
 
-    const timeRegex = /(?:(\d{1,2}):)??(?:(\d{1,2}):)?(\d{1,2}),(\d{3})/;
+    const timeRegex = /(?:(\d{1,2}):)??(?:(\d{1,2}):)?(\d{1,2}).(\d{3})/;
 
     let match = accumulatedData.match(timeRegex);
     if (!match) {


### PR DESCRIPTION
Update the regular expression to correctly parse the time format in the serial data.